### PR TITLE
Blank Redirect Catch

### DIFF
--- a/headless-mode.php
+++ b/headless-mode.php
@@ -109,7 +109,8 @@ function headless_mode_disable_front_end() {
 		! defined( 'DOING_CRON' ) &&
 		! defined( 'REST_REQUEST' ) &&
 		// prevents the case of a new user activating the plugin but not yet setting the constant. Added in 0.3.0
-		HEADLESS_MODE_CLIENT_URL !== 'https://hiroy.club' &&
+		// prevents the additional case of setting the const via an enviroment variable and forgetting to set the variable
+		! in_array(HEADLESS_MODE_CLIENT_URL, ['https://hiroy.club', '']) &&
 		! is_admin() &&
 		(
 			empty( $wp->query_vars['rest_oauth1'] ) &&


### PR DESCRIPTION
Adds catch for users who set the defined variable as blank. This issue is likely to come up for users who use ElasticBean Stalk and multiple environments. You will want to redirect to different static sites depending on the environment, ie, stage site, production site. You make the change to your code:

```
<?PHP
define( 'HEADLESS_MODE_CLIENT_URL', env('FRONTEND_SITEURL' ));
```

Now say you forgot to add that variable to an environment. That will create a redirect loop that sends the header `Location: /` and you might go slightly mad attempting to debug.