### PR TITLE
Updates tested version to reflect new WP Version

### DIFF
--- a/headless-mode.php
+++ b/headless-mode.php
@@ -7,6 +7,7 @@
  * Author: Josh Pollock, Jason Bahl, and Ben Meredith
  * Author URI: https://github.com/Shelob9/headless-mode
  * License: GPL V2
+ * Tested up to: 6.1
  * Text Domain: headless-mode
  * 
  */


### PR DESCRIPTION
I installed this on a production site this morning, and it's running a modern version of WordPress. The plugin works flawlessly as far as I can tell. I think it's safe to add the tested up to value in the plugin header.

This should remove the "last 3 versions of WordPress" warning in the plugin registry.