### PR TITLE
Updates tested version to reflect new WP Version (Part 2)

### DIFF
--- a/headless-mode.php
+++ b/headless-mode.php
@@ -7,7 +7,6 @@
  * Author: Josh Pollock, Jason Bahl, and Ben Meredith
  * Author URI: https://github.com/Shelob9/headless-mode
  * License: GPL V2
- * Tested up to: 6.1
  * Text Domain: headless-mode
  * 
  */

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: ben.meredith@gmail.com, shelob9, jasonbahl
 Donate link: https://www.wpsteward.com/donations/plugin-support/
 Tags: headless, static, gatsby, JAMstack
 Requires at least: 5.0
-Tested up to: 5.5
+Tested up to: 6.1
 Stable tag: 0.3.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
In the [last PR,](https://github.com/Shelob9/headless-mode/pull/19) I accidentally put the tested up to in the wrong place. Silly me.

I installed this on a production site this morning, and it's running a modern version of WordPress. The plugin works flawlessly as far as I can tell. I think it's safe to add the tested up to value in the plugin header.

This should remove the "last 3 versions of WordPress" warning in the plugin registry.